### PR TITLE
Pin leaflet at version 1.7

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -27,7 +27,7 @@
     },
     "require": {
         "yiisoft/yii2": "^2.0",
-        "bower-asset/leaflet": "^1.0"
+        "bower-asset/leaflet": "1.7"
     },
     "require-dev": {
         "phpunit/phpunit": "4.*"


### PR DESCRIPTION
Current leaflet 1.8 pre-release doesn't bundle the `dist/leaflet-src.js` any longer, breaking the Assets dependency